### PR TITLE
Add TypeScript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.2.1",
   "description": "Simple Streams for React",
   "main": "dist/index.js",
+  "types": "dist/index.d.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/johnlindquist/react-streams.git"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "build": "tsc",
     "dev": "tsc -w"
   },
-  "keywords": ["react", "rxjs", "streams"],
+  "keywords": [
+    "react",
+    "rxjs",
+    "streams"
+  ],
   "author": "John Lindquist",
   "license": "ISC",
   "peerDependencies": {
@@ -24,6 +28,8 @@
   },
   "devDependencies": {
     "@types/react": "^16.3.2",
+    "react": "^16.3.0",
+    "rxjs": "^6.0.0-rc.0",
     "typescript": "^2.8.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createElement, Component, createContext } from "react"
+import * as React from "react"
 
 import { Subject } from "rxjs"
 import { startWith, switchMap } from "rxjs/operators"
@@ -6,13 +6,13 @@ import { startWith, switchMap } from "rxjs/operators"
 const pipeProps = (...operations) => {
   const setState$ = new Subject()
 
-  return class extends Component {
+  return class extends React.Component {
     subscription
     state = {}
 
     __renderFn = this.props.children
       ? this.props.children
-      : this.props.render ? this.props.render : value => value
+      : (this.props as any).render ? (this.props as any).render : value => value
 
     componentDidMount() {
       this.subscription = setState$
@@ -62,9 +62,10 @@ const switchProps = (observableOrFn, optionalSelectOrValue) => (
   )
 
 const streamProviderConsumer = stream$ => {
+  const createContext = (React as any).createContext;
   const { Provider, Consumer } = createContext()
 
-  class StreamProvider extends Component {
+  class StreamProvider extends React.Component {
     subscription
     componentDidMount() {
       this.subscription = stream$.subscribe(this.setState.bind(this))
@@ -72,7 +73,7 @@ const streamProviderConsumer = stream$ => {
 
     render() {
       return this.state
-        ? createElement(Provider, { value: this.state }, this.props.children)
+        ? React.createElement(Provider, { value: this.state }, this.props.children)
         : null
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,37 @@
 import * as React from "react"
 
-import { Subject } from "rxjs"
+import { Observable, OperatorFunction, Subject } from "rxjs"
 import { startWith, switchMap } from "rxjs/operators"
 
-const pipeProps = (...operations) => {
-  const setState$ = new Subject()
+type PipedComponentType<T> = React.ComponentType<T & {
+  children?: (props: T) => React.ReactNode;
+  render?: (props: T) => React.ReactNode;
+}>
 
-  return class extends React.Component {
+function pipeProps<T>(): PipedComponentType<T>;
+function pipeProps<T, A>(op1: OperatorFunction<T, A>): PipedComponentType<A>;
+function pipeProps<T, A, B>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>): PipedComponentType<B>;
+function pipeProps<T, A, B, C>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>): PipedComponentType<C>;
+function pipeProps<T, A, B, C, D>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>): PipedComponentType<D>;
+function pipeProps<T, A, B, C, D, E>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>): PipedComponentType<E>;
+function pipeProps<T, A, B, C, D, E, F>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>): PipedComponentType<F>;
+function pipeProps<T, A, B, C, D, E, F, G>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>): PipedComponentType<G>;
+function pipeProps<T, A, B, C, D, E, F, G, H>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>): PipedComponentType<H>;
+function pipeProps<T, A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): PipedComponentType<I>;
+function pipeProps<T, R>(...operations: OperatorFunction<any, any>[]): PipedComponentType<R>;
+function pipeProps<T>(...operations) {
+  const setState$ = new Subject<T>()
+
+  return class extends React.Component<{
+    children?: (props: any) => React.ReactNode;
+    render?: (props: any) => React.ReactNode;
+  }, any> {
     subscription
     state = {}
 
-    __renderFn = this.props.children
+    __renderFn = (this.props.children
       ? this.props.children
-      : (this.props as any).render ? (this.props as any).render : value => value
+      : this.props.render ? this.props.render : value => value) as Function
 
     componentDidMount() {
       this.subscription = setState$
@@ -91,4 +110,4 @@ const sourceNext = (...args) => {
   return [subject.pipe(...args), subject.next.bind(subject)]
 }
 
-export { pipeProps, switchProps, streamProviderConsumer, sourceNext }
+export { PipedComponentType, pipeProps, switchProps, streamProviderConsumer, sourceNext }

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,10 +104,21 @@ const streamProviderConsumer = stream$ => {
   return [StreamProvider, Consumer]
 }
 
-const sourceNext = (...args) => {
-  const subject = new Subject()
+function sourceNext<T>(): [Observable<T>, (value: T) => {}];
+function sourceNext<T, A>(op1: OperatorFunction<T, A>): [Observable<A>, (value: T) => {}];
+function sourceNext<T, A, B>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>): [Observable<B>, (value: T) => {}];
+function sourceNext<T, A, B, C>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>): [Observable<C>, (value: T) => {}];
+function sourceNext<T, A, B, C, D>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>): [Observable<D>, (value: T) => {}];
+function sourceNext<T, A, B, C, D, E>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>): [Observable<E>, (value: T) => {}];
+function sourceNext<T, A, B, C, D, E, F>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>): [Observable<F>, (value: T) => {}];
+function sourceNext<T, A, B, C, D, E, F, G>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>): [Observable<G>, (value: T) => {}];
+function sourceNext<T, A, B, C, D, E, F, G, H>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>): [Observable<H>, (value: T) => {}];
+function sourceNext<T, A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): [Observable<I>, (value: T) => {}];
+function sourceNext<T, R>(...operations: OperatorFunction<T, R>[]): [Observable<R>, (value: T) => {}];
+function sourceNext<T>(...operations) {
+  const subject = new Subject<T>()
 
-  return [subject.pipe(...args), subject.next.bind(subject)]
+  return [subject.pipe(...operations), subject.next.bind(subject)]
 }
 
 export { PipedComponentType, pipeProps, switchProps, streamProviderConsumer, sourceNext }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ Covering cases:
 (ajax, ({url}) => url) //switch to creation fn, create with url from props
 */
 const switchProps = <T, P>(
-  observableOrFn: Observable<T> | ((value: T) => Observable<T>),
+  observableOrFn: Observable<T> | ((value?: T) => Observable<T>),
   optionalSelectOrValue?: ((props: P) => T) | T
 ) => ((
   ...operations
@@ -71,17 +71,21 @@ const switchProps = <T, P>(
         optionalSelectOrValue instanceof Function
           ? optionalSelectOrValue(props)
           : optionalSelectOrValue
+      const hasValue = (optionalValue !== undefined)
 
       const observable =
         observableOrFn instanceof Function
-          ? (optionalValue !== undefined)
+          ? hasValue
             ? observableOrFn(optionalValue)
-            : observableOrFn.pipe(startWith(optionalValue))
-          : observableOrFn
+            : observableOrFn()
+          : hasValue
+            ? observableOrFn.pipe(startWith(optionalValue))
+            : observableOrFn
       return observable
     }),
     ...operations
-  )) as typeof pipeProps
+  )
+) as typeof pipeProps
   
 // Use a locally-declared signature for `createContext` until this PR is merged:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,10 @@ Covering cases:
 (ajax("http://")) //switch to stream, no startWith
 (ajax, ({url}) => url) //switch to creation fn, create with url from props
 */
-const switchProps = (observableOrFn, optionalSelectOrValue) => (
+const switchProps = <T, P>(
+  observableOrFn: Observable<T> | ((value: T) => Observable<T>),
+  optionalSelectOrValue?: ((props: P) => T) | T
+) => ((
   ...operations
 ) =>
   pipeProps(
@@ -78,7 +81,7 @@ const switchProps = (observableOrFn, optionalSelectOrValue) => (
       return observable
     }),
     ...operations
-  )
+  )) as typeof pipeProps
   
 // Use a locally-declared signature for `createContext` until this PR is merged:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const switchProps = (observableOrFn, optionalSelectOrValue) => (
 
       const observable =
         observableOrFn instanceof Function
-          ? optionalValue
+          ? (optionalValue !== undefined)
             ? observableOrFn(optionalValue)
             : observableOrFn.pipe(startWith(optionalValue))
           : observableOrFn

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,11 @@
     "module":
       "commonjs" /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": ["dom", "es2015"], /* Specify library files to be included in the compilation:  */
-    "allowJs": true /* Allow javascript files to be compiled. */,
+    "allowJs": false /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx":
       "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true, /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist" /* Redirect output structure to the directory. */,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
       "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     "module":
       "commonjs" /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation:  */
+    "lib": ["dom", "es2015"], /* Specify library files to be included in the compilation:  */
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx":


### PR DESCRIPTION
This PR:

* Adds the required peers as `devDependencies` so that they are automatically installed for development installations and hassles with the lock file are avoided.
* Adds the required TypeScript libraries to the `tsconfig.json` settings.
* Changes the `tsconfig.json` settings to enable the generation of the `.d.ts` file.
* Adds the `types` entry to the `package.json` file.
* Changes `index.js` to `index.ts` and adds the type declarations.
* And the [current implementation of `switchProps`](https://github.com/johnlindquist/react-streams/blob/master/src/index.js#L43) will ignore falsy values, so I've added an explicit check against `undefined`.

Several of the functions have been changed to use `function` rather and `const`, as it's necessary to declare overload signatures. (The TypeScript feature that will make this no-longer-necessary is a long way off, as far as I'm aware.)

Also, contrary to my comment on the issue, I think it is possible to type `switchProps` and I've had a go at doing just that.